### PR TITLE
프로덕션 환경에서 H2 대신 MySQL 사용 및 Health Check 타임아웃 문제 해결

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -39,6 +39,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Create application config files from secrets
+        working-directory: motionit
+        run: |
+          mkdir -p src/main/resources
+          echo "${{ secrets.APPLICATION_YML }}" > src/main/resources/application.yml
+          echo "${{ secrets.APPLICATION_PROD_YML }}" > src/main/resources/application-prod.yml
+          echo "✓ application.yml created from secret"
+          echo "✓ application-prod.yml created from secret"
+
       - name: Build and Push Docker Image
         working-directory: motionit
         run: |

--- a/motionit/Dockerfile
+++ b/motionit/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=builder /app/build/libs/*.jar app.jar
 EXPOSE 8080
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
 
 # Run application with prod profile

--- a/motionit/build.gradle.kts
+++ b/motionit/build.gradle.kts
@@ -31,7 +31,8 @@ repositories {
 
 dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
-    runtimeOnly("com.h2database:h2")
+    developmentOnly("com.h2database:h2")
+    testRuntimeOnly("com.h2database:h2")
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/motionit/scripts/deploy-blue-green.sh
+++ b/motionit/scripts/deploy-blue-green.sh
@@ -87,6 +87,7 @@ echo -e "\n${YELLOW}[4/7] Starting ${NEW_COLOR} container...${NC}"
 docker run -d \
   --name ${NEW_CONTAINER} \
   --restart unless-stopped \
+  --add-host=host.docker.internal:host-gateway \
   -p ${NEW_PORT}:8080 \
   -e SPRING_PROFILES_ACTIVE=prod \
   -e DATABASE_URL="${DATABASE_URL}" \


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## PR / 과제 설명 
  - GitHub Actions 배포 시 컨테이너 시작 실패 (`Process exited with status 1`)
  - H2가 MySQL 대신 사용됨
  - Health Check 타임아웃 (30초 내 응답 실패)
  - App 컨테이너에서 호스트 MySQL 연결 불가

 ### 변경 파일
   - `.github/workflows/backend-cd.yml` - yml 파일 동적 생성
   - `motionit/Dockerfile` - Health Check 타임아웃 증가
   - `motionit/build.gradle.kts` - H2 스코프 변경
   - `motionit/scripts/deploy-blue-green.sh` - Docker 호스트 연결 설정

