### PR TITLE
refactor: Challenge Room 도메인 getRoom N+1 문제 fetch join 사용

### DIFF
--- a/motionit/build.gradle.kts
+++ b/motionit/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
-    implementation("io.github.openfeign.querydsl:querydsl-core:7.1")
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:7.1")
     kapt("io.github.openfeign.querydsl:querydsl-apt:7.1:jpa")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/entity/ChallengeRoom.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/entity/ChallengeRoom.kt
@@ -43,7 +43,6 @@ class ChallengeRoom(
         mappedBy = "challengeRoom",
         cascade = [CascadeType.PERSIST, CascadeType.REMOVE],
         orphanRemoval = true,
-        fetch = FetchType.LAZY
     )
     private val challengeVideoList: MutableList<ChallengeVideo> = mutableListOf()
 
@@ -51,7 +50,6 @@ class ChallengeRoom(
         mappedBy = "challengeRoom",
         cascade = [CascadeType.PERSIST, CascadeType.REMOVE],
         orphanRemoval = true,
-        fetch = FetchType.LAZY
     )
     private val participants: MutableList<ChallengeParticipant> = mutableListOf()
 

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomRepository.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomRepository.kt
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.*
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
-interface ChallengeRoomRepository : JpaRepository<ChallengeRoom, Long> {
+interface ChallengeRoomRepository : JpaRepository<ChallengeRoom, Long>, ChallengeRoomRepositoryCustom {
     // PESSIMISTIC_WRITE 락을 사용하여 해당 챌린지룸을 수정할 때 다른 트랜잭션이 접근하지 못하도록 함
     // 유저 참가시에 정원 초과를 방지하기 위해 사용, 단순 조회(목록 등)에는 절대 쓰지 말것
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomRepositoryCustom.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomRepositoryCustom.kt
@@ -1,0 +1,7 @@
+package com.back.motionit.domain.challenge.room.repository
+
+import com.back.motionit.domain.challenge.room.entity.ChallengeRoom
+
+interface ChallengeRoomRepositoryCustom {
+    fun findDetailById(id: Long): ChallengeRoom?
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomRepositoryImpl.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.back.motionit.domain.challenge.room.repository
+
+import com.back.motionit.domain.challenge.room.entity.ChallengeRoom
+import com.back.motionit.domain.challenge.room.entity.QChallengeRoom
+import com.back.motionit.domain.challenge.video.entity.QChallengeVideo
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class ChallengeRoomRepositoryImpl(
+    private val jpaQuery: JPAQueryFactory,
+) : ChallengeRoomRepositoryCustom {
+    override fun findDetailById(id: Long): ChallengeRoom? {
+        val challengeRoom = QChallengeRoom.challengeRoom
+        val challengeVideo = QChallengeVideo.challengeVideo
+
+        return jpaQuery
+            .selectFrom(challengeRoom).distinct()
+            .leftJoin(challengeRoom.challengeVideoList, challengeVideo).fetchJoin()
+            .where(challengeRoom.id.eq(id))
+            .fetchOne()
+    }
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomSummaryRepositoryImpl.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomSummaryRepositoryImpl.kt
@@ -3,14 +3,12 @@ package com.back.motionit.domain.challenge.room.repository
 import com.back.motionit.domain.challenge.room.entity.ChallengeRoom
 import com.back.motionit.domain.challenge.video.entity.OpenStatus
 import jakarta.persistence.EntityManager
-import lombok.RequiredArgsConstructor
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
 @Repository
-@RequiredArgsConstructor
 class ChallengeRoomSummaryRepositoryImpl(
     private val manager: EntityManager
 ) : ChallengeRoomSummaryRepository {

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/service/ChallengeRoomService.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/service/ChallengeRoomService.kt
@@ -148,11 +148,8 @@ class ChallengeRoomService(
 
     @Transactional
     fun getRoom(roomId: Long): GetRoomResponse {
-        val room = challengeRoomRepository.findWithVideosById(roomId)
-
-        if (room == null) {
-            throw BusinessException(ChallengeRoomErrorCode.NOT_FOUND_ROOM)
-        }
+        val room = challengeRoomRepository.findDetailById(roomId)
+            ?: throw BusinessException(ChallengeRoomErrorCode.NOT_FOUND_ROOM)
 
         return mapToGetRoomResponse(room)
     }

--- a/motionit/src/main/java/com/back/motionit/global/config/JpaConfig.kt
+++ b/motionit/src/main/java/com/back/motionit/global/config/JpaConfig.kt
@@ -1,0 +1,16 @@
+package com.back.motionit.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JpaConfig(
+    private val entityManager: EntityManager,
+) {
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/participant/service/ChallengeParticipantServiceConcurrencyTest.kt
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/participant/service/ChallengeParticipantServiceConcurrencyTest.kt
@@ -8,6 +8,7 @@ import com.back.motionit.domain.challenge.video.service.ChallengeVideoService
 import com.back.motionit.domain.user.entity.LoginType
 import com.back.motionit.domain.user.entity.User
 import com.back.motionit.domain.user.repository.UserRepository
+import com.back.motionit.global.config.JpaConfig
 import com.back.motionit.global.event.EventPublisher
 import com.back.motionit.global.service.AwsCdnSignService
 import com.back.motionit.global.service.AwsS3Service
@@ -30,7 +31,7 @@ import java.util.concurrent.Executors
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY) // H2 사용
-@Import(ChallengeParticipantService::class)
+@Import(ChallengeParticipantService::class, JpaConfig::class)
 class ChallengeParticipantServiceConcurrencyTest {
 
     @Autowired


### PR DESCRIPTION
## 관련 이슈

- Close #120 

## PR / 과제 설명 

- Challenge Room 도메인 getRoom N+1 문제: QueryDSL 기반으로 fetch join 사용하여 개선

**추가**
- `ChallengeRoomRepositoryCustom.kt`
- `ChallengeRoomRepositoryImpl.kt`
- `JpaConfig.kt`
