### PR TITLE
refactor: 댓글 욕설 필터링 성능 개선 및 CommentService 로직 정리

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/moderation/AhoCorasick.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/moderation/AhoCorasick.kt
@@ -1,0 +1,89 @@
+package com.back.motionit.domain.challenge.comment.moderation
+
+/**
+ * BLOCK / WARN 다중 패턴 매칭용 Aho-Corasick 구현
+ * - 패턴마다 KeywordFilter.Decision (BLOCK / WARN)을 저장
+ * - search() 시 BLOCK이 하나라도 발견되면 BLOCK 우선
+ */
+class AhoCorasick {
+
+    private class Node(
+        val children: MutableMap<Char, Node> = mutableMapOf(),
+        var fail: Node? = null,
+        val outputs: MutableList<KeywordFilter.Decision> = mutableListOf(),
+    )
+
+    private val root = Node()
+
+
+    fun addPattern(pattern: String, decision: KeywordFilter.Decision) {
+        if (pattern.isBlank()) return
+
+        var node = root
+        for (ch in pattern) {
+            node = node.children.getOrPut(ch) { Node() }
+        }
+        node.outputs += decision
+    }
+
+
+    fun buildFailureLinks() {
+        val queue: ArrayDeque<Node> = ArrayDeque()
+
+
+        root.children.values.forEach { child ->
+            child.fail = root
+            queue.add(child)
+        }
+
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+
+            for ((ch, nextNode) in current.children) {
+                var failNode = current.fail
+                while (failNode != null && !failNode.children.containsKey(ch)) {
+                    failNode = failNode.fail
+                }
+
+                nextNode.fail = when {
+                    failNode == null -> root
+                    else -> failNode.children[ch] ?: root
+                }
+
+                // 실패 링크가 가리키는 노드의 outputs도 현재 노드에 합쳐줌
+                nextNode.outputs += nextNode.fail?.outputs ?: emptyList()
+
+                queue.add(nextNode)
+            }
+        }
+    }
+
+
+    fun search(text: String): KeywordFilter.Decision? {
+        var node = root
+        var foundWarn = false
+
+        for (ch in text) {
+            while (node != root && !node.children.containsKey(ch)) {
+                node = node.fail ?: root
+            }
+            node = node.children[ch] ?: root
+
+            if (node.outputs.isNotEmpty()) {
+                node.outputs.forEach { decision ->
+                    when (decision) {
+                        KeywordFilter.Decision.BLOCK -> return KeywordFilter.Decision.BLOCK
+                        KeywordFilter.Decision.WARN -> foundWarn = true
+                        else -> {}
+                    }
+                }
+            }
+        }
+
+        return if (foundWarn) {
+            KeywordFilter.Decision.WARN
+        } else {
+            null
+        }
+    }
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/service/CommentService.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/service/CommentService.kt
@@ -52,7 +52,7 @@ class CommentService(
 
     @Transactional
     fun create(roomId: Long, userId: Long, req: CommentCreateReq): CommentRes {
-        assertActiveRoomOrThrow(roomId)
+
         challengeAuthValidator.validateActiveParticipant(userId, roomId)
 
         val room: ChallengeRoom = challengeRoomRepository.findById(roomId)
@@ -108,7 +108,7 @@ class CommentService(
 
     @Transactional
     fun edit(roomId: Long, commentId: Long, userId: Long, req: CommentEditReq): CommentRes {
-        assertActiveRoomOrThrow(roomId)
+
         challengeAuthValidator.validateActiveParticipant(userId, roomId)
 
         val comment = loadActiveCommentOrThrow(roomId, commentId)
@@ -126,7 +126,7 @@ class CommentService(
 
     @Transactional
     fun delete(roomId: Long, commentId: Long, userId: Long): CommentRes {
-        assertActiveRoomOrThrow(roomId)
+
         challengeAuthValidator.validateActiveParticipant(userId, roomId)
 
         val comment = loadActiveCommentOrThrow(roomId, commentId)


### PR DESCRIPTION

- Close #107

## PR / 과제 설명 
- 댓글 욕설 필터링 로직을 Aho-Corasick 기반으로 리팩터링하여 CPU사용량과 GC·Heap 사용량 개선을 도모했습니다.
- CommentService에서 불필요한 방 존재 체크(`existsById`)를 제거하고, `findById` 기준으로 정리하여 응답 시간 개선을 도모했습니다.
- list/edit/delete 로직은 기존 도메인 정책을 유지하되, 중복 쿼리만 줄였습니다.
- 관련 단위 테스트들을 모두 새 로직에 맞게 수정하고, UnnecessaryStubbing 경고 제거했습니다.
- 단위 부하테스트 시행 해주시면 결과에 따라 추가 리팩토링 진행하겠습니다.
## 확인 사항
- [x] 모든 CommentService 테스트 통과
- [x] 필터링 예외 케이스(INAPPROPRIATE_CONTENT_WARN / BLOCK) 정상 동작
- [x] 댓글 CRUD API 응답 스펙 변경 없음
