### PR TITLE
refactor: Outbox 패턴 + 서킷 브레이커 Youtube 비디오에 적용

### DIFF
--- a/motionit/build.gradle.kts
+++ b/motionit/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     checkstyle
     jacoco
 }
+val springCloudVersion by extra("2025.0.0")
 
 group = "com.back"
 version = "0.0.1-SNAPSHOT"
@@ -31,6 +32,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     developmentOnly("com.h2database:h2")
     testRuntimeOnly("com.h2database:h2")
@@ -218,6 +220,11 @@ tasks.named<Test>("test") {
         systemProperty("junit.platform.tags.excludes", "integration")
     }
     finalizedBy(tasks.jacocoTestReport)
+}
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion")
+    }
 }
 
 tasks.register<Test>("fullTest") {

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/video/external/youtube/YoutubeMetadataResilientClient.kt
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/video/external/youtube/YoutubeMetadataResilientClient.kt
@@ -1,0 +1,19 @@
+package com.back.motionit.domain.challenge.video.external.youtube
+
+import com.back.motionit.domain.challenge.video.external.youtube.dto.YoutubeVideoMetadata
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter
+import io.github.resilience4j.retry.annotation.Retry
+import org.springframework.stereotype.Component
+
+@Component
+class YoutubeMetadataResilientClient(
+    private val delegate: YoutubeMetadataClient,
+) {
+    @CircuitBreaker(name = "youtubeMetadata")
+    @Retry(name = "youtubeMetadata")
+    @RateLimiter(name = "youtubeMetadata")
+    fun fetchMetadata(youtubeUrl: String) : YoutubeVideoMetadata {
+        return delegate.fetchMetadata(youtubeUrl)
+    }
+}

--- a/motionit/src/main/java/com/back/motionit/global/outbox/processor/OutboxEventHandler.kt
+++ b/motionit/src/main/java/com/back/motionit/global/outbox/processor/OutboxEventHandler.kt
@@ -1,7 +1,7 @@
 package com.back.motionit.global.outbox.processor
 
 import com.back.motionit.domain.challenge.video.dto.YoutubeVideoPayload
-import com.back.motionit.domain.challenge.video.external.youtube.YoutubeMetadataClient
+import com.back.motionit.domain.challenge.video.external.youtube.YoutubeMetadataResilientClient
 import com.back.motionit.domain.challenge.video.external.youtube.dto.YoutubeVideoMetadata
 import com.back.motionit.domain.challenge.video.service.ChallengeVideoService
 import com.back.motionit.global.enums.EventEnums
@@ -12,6 +12,7 @@ import com.back.motionit.global.outbox.entity.OutboxEvent
 import com.back.motionit.global.outbox.repository.OutboxEventRepository
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -21,7 +22,7 @@ class OutboxEventHandler(
     private val outboxEventRepository: OutboxEventRepository,
     private val objectMapper: ObjectMapper,
     private val videoService: ChallengeVideoService,
-    private val youtubeMetadataClient: YoutubeMetadataClient,
+    private val youtubeMetadataResilientClient: YoutubeMetadataResilientClient,
     private val eventPublisher: EventPublisher,
 ) {
     private val log = KotlinLogging.logger {}
@@ -45,6 +46,15 @@ class OutboxEventHandler(
 
             event.status = OutboxStatus.COMPLETED
             event.lastErrorMessage = null
+        } catch (ex: CallNotPermittedException) {
+            // 서킷 OPEN -> 외부 시스템이 죽은 상태
+            // attemptCount 가 증가되지 않음
+            log.warn {
+                "Circuit OPEN for youtubeMetadata, eventId=${event.id} - will retry later"
+            }
+
+            event.status = OutboxStatus.PENDING
+            event.lastErrorMessage = "CircuitOpen: ${ex.message}".take(490)
         } catch (ex: Exception) {
             log.error(ex) {
                 "OutboxProcessor = error while processing eventId=${event.id}, type=${event.eventType}, attempt=${event.attemptCount}"
@@ -69,7 +79,7 @@ class OutboxEventHandler(
         )
 
         val metadata: YoutubeVideoMetadata =
-            youtubeMetadataClient.fetchMetadata(payload.youtubeUrl)
+            youtubeMetadataResilientClient.fetchMetadata(payload.youtubeUrl)
 
         videoService.saveChallengeVideo(
             actorId = payload.userId,


### PR DESCRIPTION
## 관련 이슈

- Close #128 

## PR / 과제 설명 

- "Outbox 패턴 + 서킷브레이커"를 적용하여, 외부 서비스 연동을 안전하게 처리.
- Outbox 패턴: 내부 트랜잭션과 외부 트랜잭션을 분리하여 관리하며, 외부 트랜잭션 지연에 대응 가능
- 서킷브레이커: 외부 서비스 장애 발생 시, 지정한 값에 따라, 재시도 후, 지정 실패율에 도달하면 회피. 지정 시간 이후에 재시도
